### PR TITLE
Replace FileMover with Copier in Circonus recipe

### DIFF
--- a/Circonus/CirconusUnifiedAgent.pkg.recipe.yaml
+++ b/Circonus/CirconusUnifiedAgent.pkg.recipe.yaml
@@ -22,17 +22,17 @@ Process:
         root/private/tmp/cua: "0755"
       pkgroot: "%RECIPE_CACHE_DIR%/pkgroot"
 
-  - Processor: FileMover
+  - Processor: Copier
     Arguments:
       overwrite: true
-      source: "%RECIPE_CACHE_DIR%/downloads/%amd64_filename%"
-      target: "%RECIPE_CACHE_DIR%/pkgroot/root/private/tmp/cua/cua_amd64.tar.gz"
+      source_path: "%RECIPE_CACHE_DIR%/downloads/%amd64_filename%"
+      destination_path: "%RECIPE_CACHE_DIR%/pkgroot/root/private/tmp/cua/cua_amd64.tar.gz"
 
-  - Processor: FileMover
+  - Processor: Copier
     Arguments:
       overwrite: true
-      source: "%RECIPE_CACHE_DIR%/downloads/%arm64_filename%"
-      target: "%RECIPE_CACHE_DIR%/pkgroot/root/private/tmp/cua/cua_arm64.tar.gz"
+      source_path: "%RECIPE_CACHE_DIR%/downloads/%arm64_filename%"
+      destination_path: "%RECIPE_CACHE_DIR%/pkgroot/root/private/tmp/cua/cua_arm64.tar.gz"
 
   - Processor: FileCreator
     Arguments:


### PR DESCRIPTION
The current Circonus.pkg recipe moves the original downloads out of their original location for the purpose of PKG buidilng, but with most things autopkg we normally leave the original downloads in place.  This way `URLDownloader` only pulls a new download if one is detected.  Additionally, the current use of `FileMover` in the pkg recipe has the side effect of producing errors when used with PostProcessors (like VirusTotalAnalyzer) which by default assesses the original downloaded files.  The example error is below:
```
Processor: io.github.hjuutilainen.VirusTotalAnalyzer/VirusTotalAnalyzer: Error: [Errno 2] No such file or directory: '/Users/autopkgadmin/Library/AutoPkg/Cache/local.munki.Circonus/downloads/cua-arm64.tar.gz'
```

This change subsequently replaces `FileMover` with `Copier`, which also has the benefit of respecting `VirusTotalAnalyzer`'s setting to only run when the download has actually changed.

Verbose output after change:
```
autopkg run -vv ./CirconusUnifiedAgent.pkg.recipe.yaml
Processing ./CirconusUnifiedAgent.pkg.recipe.yaml...
WARNING: ./CirconusUnifiedAgent.pkg.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'circonus-unified-agent_\\d+.\\d+.\\d+_darwin_x86_64.tar.gz',
           'github_repo': 'circonus-labs/circonus-unified-agent',
           'include_prereleases': '',
           'sort_by_highest_tag_names': 'true'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'circonus-unified-agent_\d+.\d+.\d+_darwin_x86_64.tar.gz' among asset(s): circonus-unified-agent_0.2.6_amd64.deb, circonus-unified-agent_0.2.6_amd64.rpm, circonus-unified-agent_0.2.6_arm64.deb, circonus-unified-agent_0.2.6_arm64.rpm, circonus-unified-agent_0.2.6_darwin_all.tar.gz, circonus-unified-agent_0.2.6_darwin_arm64.tar.gz, circonus-unified-agent_0.2.6_darwin_x86_64.tar.gz, circonus-unified-agent_0.2.6_freebsd_arm64.tar.gz, circonus-unified-agent_0.2.6_freebsd_x86_64.tar.gz, circonus-unified-agent_0.2.6_linux_arm64.tar.gz, circonus-unified-agent_0.2.6_linux_x86_64.tar.gz, circonus-unified-agent_0.2.6_windows_x86_64.zip, circonus-unified-agent_checksums.txt
GitHubReleasesInfoProvider: Selected asset 'circonus-unified-agent_0.2.6_darwin_x86_64.tar.gz' from release 'v0.2.6'
{'Output': {'asset_created_at': '2022-12-06T13:24:16Z',
            'asset_url': 'https://api.github.com/repos/circonus-labs/circonus-unified-agent/releases/assets/87194320',
            'release_notes': '# v0.2.6\n'
                             '\n'
                             '* fix: sign with corp cert now that it is '
                             'working\n'
                             '\n'
                             '\n',
            'url': 'https://github.com/circonus-labs/circonus-unified-agent/releases/download/v0.2.6/circonus-unified-agent_0.2.6_darwin_x86_64.tar.gz',
            'version': '0.2.6'}}
URLDownloader
{'Input': {'filename': 'cua-amd64.tar.gz',
           'url': 'https://github.com/circonus-labs/circonus-unified-agent/releases/download/v0.2.6/circonus-unified-agent_0.2.6_darwin_x86_64.tar.gz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 06 Dec 2022 13:25:09 GMT
URLDownloader: Storing new ETag header: "0x8DAD78D4C6C557C"
URLDownloader: Downloaded /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-amd64.tar.gz
{'Output': {'download_changed': True,
            'etag': '"0x8DAD78D4C6C557C"',
            'last_modified': 'Tue, 06 Dec 2022 13:25:09 GMT',
            'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-amd64.tar.gz',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-amd64.tar.gz'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
GitHubReleasesInfoProvider
{'Input': {'CURL_PATH': '/usr/bin/curl',
           'GITHUB_TOKEN_PATH': '~/.autopkg_gh_token',
           'GITHUB_URL': 'https://api.github.com',
           'asset_regex': 'circonus-unified-agent_\\d+.\\d+.\\d+_darwin_arm64.tar.gz',
           'github_repo': 'circonus-labs/circonus-unified-agent',
           'include_prereleases': '',
           'sort_by_highest_tag_names': 'true'}}
GitHubReleasesInfoProvider: Matched regex 'circonus-unified-agent_\d+.\d+.\d+_darwin_arm64.tar.gz' among asset(s): circonus-unified-agent_0.2.6_amd64.deb, circonus-unified-agent_0.2.6_amd64.rpm, circonus-unified-agent_0.2.6_arm64.deb, circonus-unified-agent_0.2.6_arm64.rpm, circonus-unified-agent_0.2.6_darwin_all.tar.gz, circonus-unified-agent_0.2.6_darwin_arm64.tar.gz, circonus-unified-agent_0.2.6_darwin_x86_64.tar.gz, circonus-unified-agent_0.2.6_freebsd_arm64.tar.gz, circonus-unified-agent_0.2.6_freebsd_x86_64.tar.gz, circonus-unified-agent_0.2.6_linux_arm64.tar.gz, circonus-unified-agent_0.2.6_linux_x86_64.tar.gz, circonus-unified-agent_0.2.6_windows_x86_64.zip, circonus-unified-agent_checksums.txt
GitHubReleasesInfoProvider: Selected asset 'circonus-unified-agent_0.2.6_darwin_arm64.tar.gz' from release 'v0.2.6'
{'Output': {'asset_created_at': '2022-12-06T13:24:16Z',
            'asset_url': 'https://api.github.com/repos/circonus-labs/circonus-unified-agent/releases/assets/87194311',
            'release_notes': '# v0.2.6\n'
                             '\n'
                             '* fix: sign with corp cert now that it is '
                             'working\n'
                             '\n'
                             '\n',
            'url': 'https://github.com/circonus-labs/circonus-unified-agent/releases/download/v0.2.6/circonus-unified-agent_0.2.6_darwin_arm64.tar.gz',
            'version': '0.2.6'}}
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': False,
           'filename': 'cua-arm64.tar.gz',
           'prefetch_filename': False,
           'url': 'https://github.com/circonus-labs/circonus-unified-agent/releases/download/v0.2.6/circonus-unified-agent_0.2.6_darwin_arm64.tar.gz'}}
URLDownloader: Storing new Last-Modified header: Tue, 06 Dec 2022 13:25:23 GMT
URLDownloader: Storing new ETag header: "0x8DAD78D545B2F67"
URLDownloader: Downloaded /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-arm64.tar.gz
{'Output': {'download_changed': True,
            'etag': '"0x8DAD78D545B2F67"',
            'last_modified': 'Tue, 06 Dec 2022 13:25:23 GMT',
            'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-arm64.tar.gz',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-arm64.tar.gz'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'root/private': '0755',
                       'root/private/tmp': '0777',
                       'root/private/tmp/cua': '0755',
                       'scripts': '0755'},
           'pkgroot': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot'}}
PkgRootCreator: Created /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot
PkgRootCreator: Creating root/private
PkgRootCreator: Created /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/root/private
PkgRootCreator: Creating root/private/tmp
PkgRootCreator: Created /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/root/private/tmp
PkgRootCreator: Creating root/private/tmp/cua
PkgRootCreator: Created /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/root/private/tmp/cua
PkgRootCreator: Creating scripts
PkgRootCreator: Created /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/scripts
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/root/private/tmp/cua/cua_amd64.tar.gz',
           'overwrite': True,
           'source_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-amd64.tar.gz'}}
Copier: Parsed dmg results: dmg_path: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-amd64.tar.gz, dmg: , dmg_source_path: 
Copier: Copied /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-amd64.tar.gz to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/root/private/tmp/cua/cua_amd64.tar.gz
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/root/private/tmp/cua/cua_arm64.tar.gz',
           'overwrite': True,
           'source_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-arm64.tar.gz'}}
Copier: Parsed dmg results: dmg_path: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-arm64.tar.gz, dmg: , dmg_source_path: 
Copier: Copied /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-arm64.tar.gz to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/root/private/tmp/cua/cua_arm64.tar.gz
{'Output': {}}
FileCreator
{'Input': {'file_content': '#!/bin/zsh\n'
                           '\n'
                           '# Determine whether Circonus is already installed\n'
                           'if [[ -e '
                           '"/Library/LaunchDaemons/com.circonus.circonus-unified-agent.plist" '
                           ']]; then\n'
                           '    echo "Circonus LaunchDaemon is installed. '
                           'Unloading and removing..."\n'
                           '    /bin/launchctl unload '
                           '"/Library/LaunchDaemons/com.circonus.circonus-unified-agent.plist"\n'
                           '    /bin/rm -rf '
                           '"/Library/LaunchDaemons/com.circonus.circonus-unified-agent.plist"\n'
                           'fi\n',
           'file_mode': '0755',
           'file_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/scripts/preinstall'}}
FileCreator: Created file at /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/scripts/preinstall
{'Output': {}}
FileCreator
{'Input': {'file_content': '#!/bin/zsh\n'
                           '\n'
                           '# Check for API key\n'
                           'API_KEY=""\n'
                           'if [[ -z "${API_KEY}" ]]; then\n'
                           '    echo "API Key not supplied. Unable to install. '
                           'Bailing..."\n'
                           '    exit 1\n'
                           'fi\n'
                           '\n'
                           '# Create install directory if missing\n'
                           'if [[ ! -e "/opt/circonus/unified-agent" ]]; then\n'
                           '    echo "Circonus install directory not present. '
                           'Creating..."\n'
                           '    /bin/mkdir -p "/opt/circonus/unified-agent"\n'
                           'fi\n'
                           '\n'
                           '# Determine architecture and install corresponding '
                           'tarball\n'
                           'ARCH=$(/usr/bin/arch)\n'
                           'if [[ "${ARCH}" == i386 ]]; then\n'
                           '    echo "x86_64 arch detected. Installing..."\n'
                           '    /usr/bin/tar xf '
                           '"/private/tmp/cua/cua_amd64.tar.gz" --directory '
                           '/opt/circonus/unified-agent\n'
                           'else\n'
                           '    echo "x86_64 arch detected. Installing..."\n'
                           '    /usr/bin/tar xf '
                           '"/private/tmp/cua/cua_arm64.tar.gz" --directory '
                           '/opt/circonus/unified-agent\n'
                           'fi\n'
                           '\n'
                           '# Cleanup\n'
                           'echo "Cleaning up..."\n'
                           '/bin/rm -rf "/private/tmp/cua/cua_amd64.tar.gz" '
                           '"/private/tmp/cua/cua_arm64.tar.gz"\n'
                           '\n'
                           '# Setup config file\n'
                           'if [[ ! -e '
                           '"/opt/circonus/unified-agent/etc/circonus-unified-agent.conf" '
                           ']]; then\n'
                           '    echo "Config file not present. Setting up '
                           'config file..."\n'
                           '    /bin/cp '
                           '"/opt/circonus/unified-agent/etc/example-circonus-unified-agent.conf" '
                           '"/opt/circonus/unified-agent/etc/circonus-unified-agent.conf"\n'
                           'else\n'
                           '    echo "Config file already deployed."\n'
                           'fi\n'
                           '\n'
                           '# Update API key in config file\n'
                           '/usr/bin/sed -i -e "s/  api_token = \\".*\\"/  '
                           'api_token = \\"${API_KEY}\\"/" '
                           '"/opt/circonus/unified-agent/etc/circonus-unified-agent.conf"\n'
                           '\n'
                           '# Setup LaunchDaemon\n'
                           '/bin/cp '
                           '"/opt/circonus/unified-agent/service/circonus-unified-agent.macos" '
                           '"/Library/LaunchDaemons/com.circonus.circonus-unified-agent.plist"\n'
                           '/bin/launchctl load '
                           '"/Library/LaunchDaemons/com.circonus.circonus-unified-agent.plist"\n',
           'file_mode': '0755',
           'file_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/scripts/postinstall'}}
FileCreator: Created file at /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/scripts/postinstall
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'id': 'com.circonus.circonus-unified-agent',
                           'options': 'purge_ds_store',
                           'pkgname': 'Circonus Unified Agent-0.2.6',
                           'pkgroot': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/root',
                           'scripts': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/pkgroot/scripts',
                           'version': '0.2.6'}}}
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'com.circonus.circonus-unified-agent',
                                                    'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/Circonus '
                                                                'Unified '
                                                                'Agent-0.2.6.pkg',
                                                    'version': '0.2.6'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/Circonus '
                        'Unified Agent-0.2.6.pkg'}}
io.github.hjuutilainen.VirusTotalAnalyzer/VirusTotalAnalyzer
{'Input': {'CURL_PATH': '/usr/bin/curl',
           'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-arm64.tar.gz'}}
VirusTotalAnalyzer: Skipping VirusTotal analysis: no new download.
{'Output': {}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/receipts/CirconusUnifiedAgent.pkg.recipe-receipt-20230102-180127.plist

The following new items were downloaded:
    Download Path                                                                                                         
    -------------                                                                                                         
    /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-amd64.tar.gz  
    /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/downloads/cua-arm64.tar.gz  

The following packages were built:
    Identifier                           Version  Pkg Path                                                                                                                    
    ----------                           -------  --------                                                                                                                    
    com.circonus.circonus-unified-agent  0.2.6    /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.CirconusUnifiedAgent/Circonus Unified Agent-0.2.6.pkg  
```