### PR TITLE
Update LogiOptionsPlus.pkg.recipe.yaml

### DIFF
--- a/Logitech/LogiOptionsPlus.pkg.recipe.yaml
+++ b/Logitech/LogiOptionsPlus.pkg.recipe.yaml
@@ -24,6 +24,11 @@ Process:
       source: "%found_filename%"
       target: "%RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus.app"
 
+  - Processor: com.github.dataJAR-recipes.Shared Processors/QuarantineRemover
+    Arguments:
+      quarantined_files_path: "%RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus.app"
+
+
   - Processor: FileCreator
     Arguments:
       file_path: "%RECIPE_CACHE_DIR%/pkg/scripts/postinstall"


### PR DESCRIPTION
Hi, @wegotoeleven 

This PR adds in `QuarantineRemover` (hosted in the dataJAR repo) to remove the quarentine bit from the installer.app before it gets packaged. 

output from a successful run

```
autopkg run -v /Users/paul.cossey/Documents/GitHub/AutoPkg\ Repos/wegotoeleven-recipes/Logitech/LogiOptionsPlus.pkg.recipe.yaml 
Looking for com.github.wegotoeleven-recipes.download.LogiOptionsPlus...
Did not find com.github.wegotoeleven-recipes.download.LogiOptionsPlus in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.wegotoeleven-recipes.download.LogiOptionsPlus...
Found com.github.wegotoeleven-recipes.download.LogiOptionsPlus in recipe map
**load_recipe time: 0.025909459000104107
Processing /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/wegotoeleven-recipes/Logitech/LogiOptionsPlus.pkg.recipe.yaml...
WARNING: /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/wegotoeleven-recipes/Logitech/LogiOptionsPlus.pkg.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 05 Oct 2023 15:58:41 GMT
URLDownloader: Storing new ETag header: "5e4a9a7bde3eb02be5f4a3e2fc95cf79"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/downloads/Logi OptionsPlus.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename Logi OptionsPlus.zip
Unarchiver: Unarchived /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/downloads/Logi OptionsPlus.zip to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/unzip
FileFinder
FileFinder: Found file match: '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/unzip/logioptionsplus_installer.app' from globbed '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/unzip/*.app'
FileFinder: Basename match: 'logioptionsplus_installer.app'
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/unzip/logioptionsplus_installer.app: valid on disk
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/unzip/logioptionsplus_installer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/unzip/logioptionsplus_installer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
PlistReader
PlistReader: Reading: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/unzip/logioptionsplus_installer.app/Contents/Info.plist
PlistReader: Assigning value of '1.54.0.466136' to output variable 'version'
PlistReader: Assigning value of 'com.logi.optionsplus.installer' to output variable 'BUNDLE_ID'
PkgRootCreator
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/pkg
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/pkg/root
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/pkg/root/private
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/pkg/root/private/tmp
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/pkg/scripts
FileMover
FileMover: File /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/unzip/logioptionsplus_installer.app moved to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/pkg/root/private/tmp/logioptionsplus.app
com.github.dataJAR-recipes.Shared Processors/QuarantineRemover
QuarantineRemover: Removed com.apple.quarantine from /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/pkg/root/private/tmp/logioptionsplus.app...
FileCreator
FileCreator: Created file at /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/pkg/scripts/postinstall
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/unzip
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/receipts/LogiOptionsPlus.pkg.recipe-receipt-20231012-202006.plist

The following new items were downloaded:
    Download Path                                                                                                                
    -------------                                                                                                                
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/downloads/Logi OptionsPlus.zip  

The following packages were built:
    Identifier                      Version        Pkg Path                                                                                                                         
    ----------                      -------        --------                                                                                                                         
    com.logi.optionsplus.installer  1.54.0.466136  /Users/paul.cossey/Library/AutoPkg/Cache/com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus/Logi OptionsPlus-1.54.0.466136.pkg
```