### PR TITLE
Tart architecture support

### DIFF
--- a/Cirrus Labs/Tart.download.recipe.yaml
+++ b/Cirrus Labs/Tart.download.recipe.yaml
@@ -1,9 +1,10 @@
-Description: Downloads the latest version of Tart from Github.
+Description: Downloads the latest version of Tart from Github. Specifiy an ARCH of "arm64" for Apple Silicon or "amd64" for Intel.
 Identifier: com.github.wegotoeleven-recipes.download.Tart
 MinimumVersion: '2.3'
 
 Input:
   NAME: Tart
+  ARCH: arm64
   GITHUB_REPO: cirruslabs/tart
   INCLUDE_PRERELEASES: "false"
 
@@ -11,7 +12,7 @@ Process:
 
   - Processor: GitHubReleasesInfoProvider
     Arguments:
-      asset_regex: ^tart.*?tar.gz$
+      asset_regex: ^tart-%ARCH%.*?tar.gz$
       github_repo: "%GITHUB_REPO%"
       include_prereleases: "%INCLUDE_PRERELEASES%"
 

--- a/Cirrus Labs/Tart.pkg.recipe.yaml
+++ b/Cirrus Labs/Tart.pkg.recipe.yaml
@@ -1,11 +1,12 @@
 Description: Downloads the latest version of Tart from Github; pulls apart the package and checks the binary's code 
-  signature
+  signature. Specifiy an ARCH of "arm64" for Apple Silicon or "amd64" for Intel.
 Identifier: com.github.wegotoeleven-recipes.pkg.Tart
 MinimumVersion: '2.3'
 ParentRecipe: com.github.wegotoeleven-recipes.download.Tart
 
 Input:
   NAME: Tart
+  ARCH: arm64
   GITHUB_REPO: cirruslabs/tart
   INCLUDE_PRERELEASES: "false"
 
@@ -57,7 +58,7 @@ Process:
   - Processor: PkgCreator
     Arguments:
       pkg_request:
-        pkgname: "%NAME%-%version%"
+        pkgname: "%NAME%-%ARCH%-%version%"
         pkgdir: "%RECIPE_CACHE_DIR%"
         id: com.github.cirruslabs.tart-app
         options: purge_ds_store


### PR DESCRIPTION
This adds architecture support to the Tart recipes.

Cirrus Labs began shipping an Intel (x86_64/amd64) build of the app back in January. Previously there was only an Apple Silicon (arm64) release.

The current recipe pulls the Intel release because it is first alphabetically on GitHub, which is likely what users are not expecting.

This change allows admins to specify if they want the "arm64" or "amd64" release.