### PR TITLE
Update Tart

### DIFF
--- a/Cirrus Labs/Tart.download.recipe.yaml
+++ b/Cirrus Labs/Tart.download.recipe.yaml
@@ -1,10 +1,9 @@
-Description: Downloads the latest version of Tart from Github. Specifiy an ARCH of "arm64" for Apple Silicon or "amd64" for Intel.
+Description: Downloads the latest version of Tart from Github.
 Identifier: com.github.wegotoeleven-recipes.download.Tart
 MinimumVersion: '2.3'
 
 Input:
   NAME: Tart
-  ARCH: arm64
   GITHUB_REPO: cirruslabs/tart
   INCLUDE_PRERELEASES: "false"
 
@@ -12,7 +11,7 @@ Process:
 
   - Processor: GitHubReleasesInfoProvider
     Arguments:
-      asset_regex: ^tart-%ARCH%.*?tar.gz$
+      asset_regex: ^tart.tar.gz$
       github_repo: "%GITHUB_REPO%"
       include_prereleases: "%INCLUDE_PRERELEASES%"
 

--- a/Cirrus Labs/Tart.download.recipe.yaml
+++ b/Cirrus Labs/Tart.download.recipe.yaml
@@ -8,6 +8,11 @@ Input:
   INCLUDE_PRERELEASES: "false"
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      message: >
+        ⚠️ The recipe com.github.wegotoeleven-recipes.download.Tart is deprecated.
+        Please use com.github.kevinmcox.download.Tart going forward.
 
   - Processor: GitHubReleasesInfoProvider
     Arguments:

--- a/Cirrus Labs/Tart.pkg.recipe.yaml
+++ b/Cirrus Labs/Tart.pkg.recipe.yaml
@@ -1,12 +1,11 @@
 Description: Downloads the latest version of Tart from Github; pulls apart the package and checks the binary's code 
-  signature. Specifiy an ARCH of "arm64" for Apple Silicon or "amd64" for Intel.
+  signature.
 Identifier: com.github.wegotoeleven-recipes.pkg.Tart
 MinimumVersion: '2.3'
 ParentRecipe: com.github.wegotoeleven-recipes.download.Tart
 
 Input:
   NAME: Tart
-  ARCH: arm64
   GITHUB_REPO: cirruslabs/tart
   INCLUDE_PRERELEASES: "false"
 

--- a/Cirrus Labs/Tart.pkg.recipe.yaml
+++ b/Cirrus Labs/Tart.pkg.recipe.yaml
@@ -57,7 +57,7 @@ Process:
   - Processor: PkgCreator
     Arguments:
       pkg_request:
-        pkgname: "%NAME%-%ARCH%-%version%"
+        pkgname: "%NAME%-%version%"
         pkgdir: "%RECIPE_CACHE_DIR%"
         id: com.github.cirruslabs.tart-app
         options: purge_ds_store

--- a/Cirrus Labs/Tart.pkg.recipe.yaml
+++ b/Cirrus Labs/Tart.pkg.recipe.yaml
@@ -10,6 +10,11 @@ Input:
   INCLUDE_PRERELEASES: "false"
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      message: >
+        ⚠️ The recipe "com.github.wegotoeleven-recipes.pkg.Tart" is deprecated.
+        Please use "com.github.kevinmcox.pkg.Tart" going forward.
 
   - Processor: Unarchiver
     Arguments:


### PR DESCRIPTION
Tart now ships as a Universal application so we can remove the architecture variable that was added last year.

EDIT: Added `DeprecationWarnings` after discussion and have adopted the recipes into my repo here: https://github.com/autopkg/kevinmcox-recipes/tree/master/Cirrus%20Labs