### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Circonus/CirconusUnifiedAgent.pkg.recipe.yaml
+++ b/Circonus/CirconusUnifiedAgent.pkg.recipe.yaml
@@ -136,7 +136,6 @@ Process:
     Arguments:
       pkg_request:
         id: com.circonus.circonus-unified-agent
-        options: purge_ds_store
         pkgname: "%NAME%-%version%"
         pkgroot: "%pkgroot%/root"
         scripts: "%pkgroot%/scripts"

--- a/Cirrus Labs/Tart.pkg.recipe.yaml
+++ b/Cirrus Labs/Tart.pkg.recipe.yaml
@@ -65,7 +65,6 @@ Process:
         pkgname: "%NAME%-%version%"
         pkgdir: "%RECIPE_CACHE_DIR%"
         id: com.github.cirruslabs.tart-app
-        options: purge_ds_store
         scripts: scripts
         version: "%version%"
         chown:

--- a/Docker/DockerUniversal.pkg.recipe.yaml
+++ b/Docker/DockerUniversal.pkg.recipe.yaml
@@ -33,7 +33,6 @@ Process:
             path: Applications
             user: root
         id: "%BUNDLE_ID%.amd64"
-        options: purge_ds_store
         pkgname: "%NAME%-amd64-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/amd64"
         version: "%version%"
@@ -61,7 +60,6 @@ Process:
             path: Applications
             user: root
         id: "%BUNDLE_ID%.arm64"
-        options: purge_ds_store
         pkgname: "%NAME%-arm64-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/arm64"
         version: "%version%"
@@ -194,7 +192,6 @@ Process:
     Arguments:
       pkg_request:
         id: "%BUNDLE_ID%"
-        options: purge_ds_store
         pkgname: "%NAME%Universal-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/universal/root"
         scripts: "%RECIPE_CACHE_DIR%/universal/scripts"

--- a/Logitech/LogiBolt.pkg.recipe.yaml
+++ b/Logitech/LogiBolt.pkg.recipe.yaml
@@ -46,7 +46,6 @@ Process:
     Arguments:
       pkg_request:
         id: "%BUNDLE_ID%"
-        options: purge_ds_store
         pkgname: "%NAME%-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/pkg/root"
         scripts: "%RECIPE_CACHE_DIR%/pkg/scripts"

--- a/Logitech/LogiOptionsPlus.pkg.recipe.yaml
+++ b/Logitech/LogiOptionsPlus.pkg.recipe.yaml
@@ -51,7 +51,6 @@ Process:
     Arguments:
       pkg_request:
         id: "%BUNDLE_ID%"
-        options: purge_ds_store
         pkgname: "%NAME%-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/pkg/root"
         scripts: "%RECIPE_CACHE_DIR%/pkg/scripts"

--- a/Miro/MiroUniversal.pkg.recipe.yaml
+++ b/Miro/MiroUniversal.pkg.recipe.yaml
@@ -33,7 +33,6 @@ Process:
             path: Applications
             user: root
         id: "%BUNDLE_ID%.i386"
-        options: purge_ds_store
         pkgname: "%NAME%-i386-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/i386"
         version: "%version%"
@@ -61,7 +60,6 @@ Process:
             path: Applications
             user: root
         id: "%BUNDLE_ID%.arm64"
-        options: purge_ds_store
         pkgname: "%NAME%-arm64-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/arm64"
         version: "%version%"
@@ -125,7 +123,6 @@ Process:
     Arguments:
       pkg_request:
         id: "%BUNDLE_ID%"
-        options: purge_ds_store
         pkgname: "%NAME%Universal-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/universal/root"
         scripts: "%RECIPE_CACHE_DIR%/universal/scripts"

--- a/VirtualBuddy/VirtualBuddy.pkg.recipe.yaml
+++ b/VirtualBuddy/VirtualBuddy.pkg.recipe.yaml
@@ -33,7 +33,6 @@ Process:
             path: Applications
             user: root
         id: "%bundleid%"
-        options: purge_ds_store
         pkgname: "%NAME%-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/root"
         version: "%version%"

--- a/Yubico/YubicoAuthenticator.pkg.recipe.yaml
+++ b/Yubico/YubicoAuthenticator.pkg.recipe.yaml
@@ -33,7 +33,6 @@ Process:
             path: Applications
             user: root
         id: "%bundleid%"
-        options: purge_ds_store
         pkgname: "%NAME%-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/root"
         version: "%version%"


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._