### PR TITLE
Update ParentRecipe reference in LogiOptionsPlus recipe

### DIFF
--- a/Logitech/LogiOptionsPlus.pkg.recipe.yaml
+++ b/Logitech/LogiOptionsPlus.pkg.recipe.yaml
@@ -2,7 +2,7 @@ Description: Downloads the latest version of the Logi Options+ installer app, an
   deploys the installer to /tmp in then installs the app silently.
 Identifier: com.github.wegotoeleven-recipes.pkg.LogiOptionsPlus
 MinimumVersion: '2.3'
-ParentRecipe: com.github.wegotoeleven-recipes.download.LogiOptionsPlus
+ParentRecipe: com.github.TekTekkers.download.logioptionsplus_installer
 
 Input:
   NAME: Logi OptionsPlus


### PR DESCRIPTION
Hi, @wegotoeleven 

This PR changes the ParentRecipe to use `com.github.TekTekkers.download.logioptionsplus_installer` due to the deprecation of your download recipe. 

Related to upstream issue: https://github.com/autopkg/dataJAR-recipes/issues/494