### PR TITLE
Add Logi OptionsPlus Offline installer recipes (download + pkg)

### DIFF
--- a/LogiOptionsPlusOffline.pkg.recipe.yaml
+++ b/LogiOptionsPlusOffline.pkg.recipe.yaml
@@ -1,0 +1,62 @@
+Description: Downloads the latest version of the Logi Options+ offline installer app, and creates a package. This package
+  deploys the installer to /tmp in then installs the app silently.
+Identifier: com.github.wegotoeleven-recipes.pkg.LogiOptionsPlusOffline
+MinimumVersion: '2.3'
+ParentRecipe: com.github.wegotoeleven-recipes.download.LogiOptionsPlusOffline
+
+Input:
+  NAME: Logi OptionsPlus Offline
+  URL: https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_offline.zip
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgdirs:
+        scripts: "0755"
+        root: "0755"
+        root/private: "0755"
+        root/private/tmp: "0777"
+      pkgroot: "%RECIPE_CACHE_DIR%/pkg"
+
+  - Processor: FileMover
+    Arguments:
+      overwrite: false
+      source: "%found_filename%"
+      target: "%RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus_installer_offline.app"
+
+  - Processor: com.github.dataJAR-recipes.Shared Processors/QuarantineRemover
+    Arguments:
+      quarantined_files_path: "%RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus_installer_offline.app"
+
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: "%RECIPE_CACHE_DIR%/pkg/scripts/postinstall"
+      file_mode: "0755"
+      file_content: |
+        #!/bin/zsh
+
+        # Check exit code and bail if the package didn't install correctly
+        if [[ -e "/private/tmp/logioptionsplus_installer_offline.app" ]]; then
+            if ! "/private/tmp/logioptionsplus_installer_offline.app/Contents/MacOS/logioptionsplus_installer" --quiet; then
+                echo "Issues occurred during the installation of Logi Options+. Please check the install log and try again."
+                exit 1
+            fi
+        else
+            echo "Unable to find Logi Options+ Offline installer. Bailing..."
+            exit 1
+        fi
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: "%BUNDLE_ID%"
+        pkgname: "%NAME%-%version%"
+        pkgroot: "%RECIPE_CACHE_DIR%/pkg/root"
+        scripts: "%RECIPE_CACHE_DIR%/pkg/scripts"
+        version: "%version%"
+
+  - Processor: PathDeleter
+    Arguments:
+      path_list:
+        - "%RECIPE_CACHE_DIR%/unzip"

--- a/Logitech/LogiOptionsPlusOffline.download.recipe.yaml
+++ b/Logitech/LogiOptionsPlusOffline.download.recipe.yaml
@@ -1,0 +1,37 @@
+Description: Unzip the latest version of the Logi Options+ offline installer app
+Identifier: com.github.wegotoeleven-recipes.download.LogiOptionsPlusOffline
+MinimumVersion: '2.3'
+
+Input:
+  NAME: Logi OptionsPlus Offline
+  URL: https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_offline.zip
+
+Process:
+  - Processor: URLDownloader
+    Arguments:
+      filename: "%NAME%.zip"
+      url: "%URL%"
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: "%pathname%"
+      destination_path: "%RECIPE_CACHE_DIR%/unzip"
+      purge_destination: true
+
+  - Processor: FileFinder
+    Arguments:
+      pattern: "%RECIPE_CACHE_DIR%/unzip/*.app"
+
+  - Processor: CodeSignatureVerifier
+    Arguments: 
+      input_path: "%found_filename%"
+      requirement: identifier "com.logi.optionsplus.installer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = QED4VVPZWA
+
+  - Processor: PlistReader
+    Arguments:
+      info_path: "%found_filename%/Contents/Info.plist"
+      plist_keys:
+          CFBundleVersion: version
+          CFBundleIdentifier: BUNDLE_ID


### PR DESCRIPTION
## Why

Logitech publishes a separate "offline installer" for Options+, intended for air-gapped/no-internet machines and mass deployments. It has its own download URL and its own app bundle name, so it isn't covered by the existing `LogiOptionsPlus.download.recipe.yaml` / `LogiOptionsPlus.pkg.recipe.yaml` pair. This PR adds a parallel pair of recipes for that offline installer, mirroring the structure of the existing Logi OptionsPlus recipes.

Docs referenced from Logitech:
- [Logi Options+ Offline Manual](https://hub.sync.logitech.com/options/post/logi-options-offline-manual-I2a7NSJyE6oH2oy)
- [Options+ Silent Installation & Feature Flags](https://hub.sync.logitech.com/options/post/options-silent-installation-feature-flags-RnX8O7v5xTQ41mq)
- [Options+ Mass Installation (macOS)](https://sync.logitech.com/hub/options/post/options-mass-installation-macos-2m9kVszkzbfpYEJ)

## What changed

- **`Logitech/LogiOptionsPlusOffline.download.recipe.yaml`** (new) - downloads `logioptionsplus_installer_offline.zip`, unzips it, verifies the code signature, and reads version/bundle-id from the app's `Info.plist`. Structurally identical to `LogiOptionsPlus.download.recipe.yaml`.
- **`Logitech/LogiOptionsPlusOffline.pkg.recipe.yaml`** (new) - stages the offline installer app to `/private/tmp` and runs it silently (`--quiet`) via a postinstall script, then builds a `.pkg`. Structurally identical to `LogiOptionsPlus.pkg.recipe.yaml`.

## Notes for reviewers (context you may not have)

- The offline installer's app bundle is named `logioptionsplus_installer_offline.app` (vs. `logioptionsplus_installer.app` for the online installer), but it reports the **same** `CFBundleIdentifier` (`com.logi.optionsplus.installer`) and is signed with the **same** Developer ID (`QED4VVPZWA`) as the online installer. So the existing `CodeSignatureVerifier` requirement string and `PlistReader` keys carry over unchanged, and the built `.pkg` intentionally uses that same identifier (consistent with how the existing online `pkg` recipe already does it) rather than inventing a new one.
- The offline installer binary supports the identical `--quiet` and feature-flag arguments (`--analytics`, `--flow`, `--sso`, `--update`, etc.) as the online installer, confirmed by running `--help` against the actual downloaded binary.
- The offline zip is much larger than the online one (~1.3 GB uncompressed, stored/not compressed) - expect a slower first `autopkg run`.

## Testing performed

Both recipes were run end-to-end with real AutoPkg (via a temporary local override, since they're new/unaudited recipes):
- Download recipe: downloaded the real zip, unarchived it, `CodeSignatureVerifier` passed, `PlistReader` correctly extracted `version = 2.4.903778` and `BUNDLE_ID = com.logi.optionsplus.installer`.
- Pkg recipe: built `Logi OptionsPlus Offline-2.4.903778.pkg`; expanded the resulting package and confirmed the payload stages the app under `/private/tmp` and the `postinstall` script correctly invokes `Contents/MacOS/logioptionsplus_installer --quiet`.